### PR TITLE
Fix for potentially undefined `cause` property in `fromJSON`

### DIFF
--- a/src/AbstractError.ts
+++ b/src/AbstractError.ts
@@ -30,7 +30,6 @@ class AbstractError<T> extends CustomError {
       typeof json.data.message !== 'string' ||
       isNaN(Date.parse(json.data.timestamp)) ||
       typeof json.data.data !== 'object' ||
-      !('cause' in json.data) ||
       ('stack' in json.data && typeof json.data.stack !== 'string')
     ) {
       throw new TypeError(`Cannot decode JSON to ${this.name}`);
@@ -84,6 +83,9 @@ class AbstractError<T> extends CustomError {
   /**
    * Encoding to JSON pojo
    * When overriding this, you can use `super.toJSON`
+   * The `replacer` will:
+   *  - delete undefined values in objects
+   *  - replace undefined values for null in arrays
    */
   public toJSON(): any {
     return {


### PR DESCRIPTION
### Description
<!-- Write your description about what this PR is about. -->
Since the JSON `replacer` function removes undefined values, it is incorrect to assume that the `cause` property will always exist in a serialised `AbstractError`. Thus, this was removed from the checking done in `fromJSON`.

### Tasks
<!-- 
  List all tasks to be done by this PR.
  If a task is no longer required, add a strikethrough (including the checkbox):
  - ~~[ ] 3. ...~~ - being completed in #...
-->
- [x] 1. Remove check for `cause` property in `fromJSON` in `AbstractError`
- [x] 2. Add documentation for `replacer` regarding the removal of undefined properties

### Final checklist
<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
* [x] Full tests
* [x] Updated inline-comment documentation
* [x] Lint fixed
* [x] Sanity check the final build
